### PR TITLE
Improved the error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### next
+
+* Added support for custom error handling and improved the default error
+  handling on FactoryBot usage (#9)
+
 ### 0.5.1
 
 * Corrected a bug on the scenario description update (#8)

--- a/README.md
+++ b/README.md
@@ -316,6 +316,18 @@ FactoryBot::Instrumentation.configure do |conf|
     controller.render plain: entity.to_json,
                       content_type: 'application/json'
   end
+  # By default we assemble a JSON response on errors which may be
+  # helpful for debugging, but you can configure your own logic here
+  conf.render_error = proc do |controller, error|
+    app_name = FactoryBot::Instrumentation.configuration.application_name
+    controller.render status: :internal_server_error,
+                      content_type: 'application/json',
+                      plain: {
+                        application: app_name,
+                        error: error.message,
+                        backtrace: error.backtrace.join("\n")
+                      }.to_json
+  end
   # By default we do not perform any custom +before_action+ filters on the
   # instrumentation controllers, with this option you can implement your
   # custom logic like authentication

--- a/app/controllers/factory_bot/instrumentation/root_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/root_controller.rb
@@ -43,9 +43,8 @@ module FactoryBot::Instrumentation
       # Render the resulting entity with the configured rendering block
       FactoryBot::Instrumentation.configuration.render_entity.call(self, entity)
     rescue StandardError => err
-      # Log for local factory debugging and re-raise for canary onwards
-      Rails.logger.error("#{err}\n#{err.backtrace.join("\n")}")
-      raise err
+      # Handle any error gracefully with the configured error handler
+      FactoryBot::Instrumentation.configuration.render_error.call(self, err)
     end
 
     private

--- a/lib/factory_bot/instrumentation/configuration.rb
+++ b/lib/factory_bot/instrumentation/configuration.rb
@@ -25,6 +25,21 @@ module FactoryBot
         end
       end
 
+      # By default we assemble a JSON response on errors which may be
+      # helpful for debugging, but you can configure your own logic here
+      config_accessor(:render_error) do
+        proc do |controller, error|
+          app_name = FactoryBot::Instrumentation.configuration.application_name
+          controller.render status: :internal_server_error,
+                            content_type: 'application/json',
+                            plain: {
+                              application: app_name,
+                              error: error.message,
+                              backtrace: error.backtrace.join("\n")
+                            }.to_json
+        end
+      end
+
       # By default we do not perform any custom +before_action+ filters on the
       # instrumentation controllers, with this option you can implement your
       # custom logic like authentication

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,11 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  # Enable the focus inclusion filter and run all when no filter is set
+  # See: http://bit.ly/2TVkcIh
+  config.filter_run(focus: true)
+  config.run_all_when_everything_filtered = true
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
When an error occurred deep in the called factory the API endpoint responded something like this:

```
ActionView::MissingTemplate:
  Missing template factory_bot/instrumentation/root/create,
  factory_bot/instrumentation/application/create with {:locale=>[:en],
  :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder,
  :ruby]}. Searched in:
    * "/app/spec/dummy/app/views"
    * "/app/app/views"      
```

Now the error handling can be customized and the default error response looks like this: 
(HTTP status code: 500)

```json
{
  "application": "Name of your Application",
  "error": "Factory not registered: \"admin\"", 
  "backtrace": "[..]"
}
```