### PR TITLE
Fix factory bot loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next
+* Added `FactoryBot.reload` to the initializer code to ensure the factories
+  are in place.
+
 ### 0.7.1
 
 * Migrated to Github Actions

--- a/lib/factory_bot/instrumentation/engine.rb
+++ b/lib/factory_bot/instrumentation/engine.rb
@@ -8,6 +8,11 @@ module FactoryBot
 
       # Fill in some dynamic settings (application related)
       initializer 'factory_bot_instrumentation.config' do
+        # Ensure the FactoryBot gem loads its factories to ensure they are
+        # also available in the rails console and other places in the app
+        # and not only via instrumentation frontend.
+        FactoryBot.reload
+
         FactoryBot::Instrumentation.configure do |conf|
           # Set the application name dynamically
           conf.application_name \


### PR DESCRIPTION
Fixes a loading issue where the factories are not usable in the rails console or other places in the app in non-dev environments. In my opinion the FactoryBot factories should be in place when the FactoryBot::Instrumentation is loaded, so no other gems like `factory_bot_rails` need to be included in non-dev environments.

without fix:
```ruby 
> FactoryBot.build :user
KeyError: Factory not registered: "user"
```  

with fix:
```ruby 
> FactoryBot.build :user
=> #<User:0x0000556e91bcf5c0>
```  