### PR TITLE
Fixed an initialization issue when used with factory_bot_rails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### next
+
+* When used in combination with the `factory_bot_rails` gem (>= 6.0) we do not
+  force a `FactoryBot.reload` at Rails engine initialization as it breaks with
+  an `FactoryBot::DuplicateDefinitionError` (#14)
+
 ### 1.0.1
 
 * Added a retry logic to the FactoryBot reloading on the POST/create endpoint

--- a/factory_bot_instrumentation.gemspec
+++ b/factory_bot_instrumentation.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.4'
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'countless', '~> 1.1'
+  spec.add_development_dependency 'factory_bot_rails', '~> 6.2'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'railties', '>= 5.2'
   spec.add_development_dependency 'rspec-rails', '~> 5.1'

--- a/lib/factory_bot/instrumentation/engine.rb
+++ b/lib/factory_bot/instrumentation/engine.rb
@@ -7,11 +7,16 @@ module FactoryBot
       isolate_namespace FactoryBot::Instrumentation
 
       # Fill in some dynamic settings (application related)
-      initializer 'factory_bot_instrumentation.config' do
-        # Ensure the FactoryBot gem loads its factories to ensure they are
-        # also available in the rails console and other places in the app
-        # and not only via instrumentation frontend.
-        FactoryBot.reload
+      initializer 'factory_bot_instrumentation.config' do |app|
+        # Ensure the FactoryBot gem loads its factories to ensure they are also
+        # available in the rails console and other places in the app and not
+        # only via instrumentation frontend. We skip this step as in
+        # combination with the +factory_bot_rails+ gem (>=6.0) the FactoryBot
+        # initializing occurs after the Rails application initializing, which
+        # leads to +FactoryBot::DuplicateDefinitionError+s.
+        initializer_names = app.initializers.map(&:name).map(&:to_s)
+        FactoryBot.reload \
+          if initializer_names.grep(/^factory_bot\./).count.zero?
 
         FactoryBot::Instrumentation.configure do |conf|
           # Set the application name dynamically

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -5,6 +5,11 @@ require_relative 'boot'
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
+
+# When required on the specs, we load the rails binding
+require 'factory_bot_rails' \
+  if ENV.fetch('FACTORY_BOT_RAILS', 'false') == 'true'
+
 require 'factory_bot_instrumentation'
 
 module Dummy

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -45,4 +45,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # When required on the specs, we load the rails binding
+  if ENV.fetch('FACTORY_BOT_RAILS', 'false') == 'true'
+    # We must make sure the dummy app loads the gem factories
+    config.factory_bot.definition_file_paths << Rails.root.join('../factories')
+  end
 end

--- a/spec/factory_bot/instrumentation/engine/with_factory_bot_rails_spec.rb
+++ b/spec/factory_bot/instrumentation/engine/with_factory_bot_rails_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+ENV['FACTORY_BOT_RAILS'] = 'true'
+require 'spec_helper'
+
+RSpec.describe FactoryBot::Instrumentation::Engine do
+  context 'with factory_bot_rails' do
+    it 'does not raise' do
+      expect { Rails.application }.not_to raise_error
+    end
+  end
+end

--- a/spec/factory_bot/instrumentation/engine/without_factory_bot_rails_spec.rb
+++ b/spec/factory_bot/instrumentation/engine/without_factory_bot_rails_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+ENV['FACTORY_BOT_RAILS'] = 'false'
+require 'spec_helper'
+
+RSpec.describe FactoryBot::Instrumentation::Engine do
+  context 'without factory_bot_rails' do
+    it 'does not raise' do
+      expect { Rails.application }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
```
FactoryBot::DuplicateDefinitionError: Factory already registered: address
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/decorator.rb:21:in `method_missing'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/decorator/disallows_duplicates_registry.rb:6:in `register'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/internal.rb:64:in `block in register_factory'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/internal.rb:63:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/internal.rb:63:in `register_factory'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/syntax/default.rb:20:in `factory'
/app/spec/factories/addresses.rb:20:in `block in <top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/syntax/default.rb:37:in `instance_eval'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/syntax/default.rb:37:in `run'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/syntax/default.rb:7:in `define'
/app/spec/factories/addresses.rb:19:in `<top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:55:in `load'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:55:in `load'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `block in load'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:285:in `load'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/find_definitions.rb:20:in `block (2 levels) in find_definitions'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/find_definitions.rb:19:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/find_definitions.rb:19:in `block in find_definitions'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/find_definitions.rb:15:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot-6.2.1/lib/factory_bot/find_definitions.rb:15:in `find_definitions'
/app/vendor/bundle/ruby/2.5.0/gems/factory_bot_rails-6.2.0/lib/factory_bot_rails/railtie.rb:22:in `block in <class:Railtie>'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:51:in `each'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/application/finisher.rb:75:in `block in <module:Finisher>'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `instance_exec'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `run'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:60:in `run_initializers'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/application.rb:361:in `initialize!'
/app/config/environment.rb:7:in `<top (required)>'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/app/vendor/bundle/ruby/2.5.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/zeitwerk-2.6.0/lib/zeitwerk/kernel.rb:35:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `block in require'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:257:in `load_dependency'
/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies.rb:291:in `require'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/application.rb:337:in `require_environment!'
/app/vendor/bundle/ruby/2.5.0/gems/railties-5.2.8.1/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/app/vendor/bundle/ruby/2.5.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
/usr/local/bundle/bin/bundle:25:in `load'
/usr/local/bundle/bin/bundle:25:in `<main>'
```