### PR TITLE
Added a view path fallback handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next
 
 * Moved the development dependencies from the gemspec to the Gemfile (#15)
+* Added a fallback view path handling in case an Rails application cannot
+  find our engine templates correctly (#16)
 
 ### 1.1.1
 

--- a/app/controllers/factory_bot/instrumentation/application_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/application_controller.rb
@@ -9,6 +9,11 @@ module FactoryBot
       include ActionController::HttpAuthentication::Digest::ControllerMethods
       include ActionController::HttpAuthentication::Token::ControllerMethods
 
+      # For some reason the Rails engine may not find its partial templates as
+      # it looks for wrong paths, so we add a fallback path to the view paths
+      base_path = Pathname.new(File.expand_path('../../../views', __dir__))
+      append_view_path base_path.join('factory_bot/instrumentation')
+
       # Allow the users to implement additional instrumentation-wide before
       # action logic, like authentication
       before_action do |_controller|


### PR DESCRIPTION
```
ActionView::MissingTemplate in FactoryBot::Instrumentation::Root#index
Showing /usr/local/bundle/gems/factory_bot_instrumentation-1.1.1/app/views/factory_bot/instrumentation/root/index.html.erb where line #23 raised:

Missing partial factory_bot/instrumentation/root/_spinner, application/_spinner with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}. Searched in:
  * "/app/app/views"
  * "/usr/local/bundle/gems/administrate-0.16.0/app/views"
  * "/usr/local/bundle/gems/factory_bot_instrumentation-1.1.1/app/views"
  * "/usr/local/bundle/gems/kaminari-core-1.2.2/app/views"
  * "/usr/local/bundle/gems/grape-swagger-rails-0.3.1/app/views"
```

For some reason the "factory_bot/instrumentation/**root**/_spinner" is searched for, not "factory_bot/instrumentation/**application**/_spinner" as expected in this case.