### PR TITLE
Added fallbacks for configuration processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Added fallbacks for configuration processing (#19)
 
 ### 1.1.4
 

--- a/app/controllers/factory_bot/instrumentation/root_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/root_controller.rb
@@ -89,14 +89,15 @@ module FactoryBot
         config_file = FactoryBot::Instrumentation.configuration.config_file.to_s
         template = ERB.new(Pathname.new(config_file).read)
         load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
-        YAML.send(load_method, template.result(binding))[Rails.env]
+        YAML.send(load_method, template.result(binding))[Rails.env] || {}
       end
 
       # Map all the instrumentation scenarios into groups and pass them back.
       #
       # @return [Hash{String => Array}] the grouped scenarios
       def scenarios
-        instrumentation['scenarios'].each_with_object({}) do |scenario, memo|
+        res = (instrumentation['scenarios'] || [])
+        res.each_with_object({}) do |scenario, memo|
           group = scenario_group(scenario['name'])
           scenario['group'] = group
           memo[group] = [] unless memo.key? group
@@ -108,7 +109,7 @@ module FactoryBot
       #
       # @return [Hash{Regexp => String}] the group mapping
       def groups
-        instrumentation['groups'].transform_keys do |key|
+        (instrumentation['groups'] || {}).transform_keys do |key|
           Regexp.new(Regexp.quote(key))
         end
       end


### PR DESCRIPTION
```
Showing /usr/local/bundle/gems/factory_bot_instrumentation-1.1.4/app/views/factory_bot/instrumentation/root/index.html.erb where line #6 raised:

undefined method `each' for nil:NilClass

---

factory_bot_instrumentation (1.1.4views) factory_bot/instrumentation/root/index.html.erb:6:in `__usr_local_bundle_gems_factory_bot_instrumentation______views_factory_bot_instrumentation_root_index_html_erb__3290797174427525861_46917444733660'
actionview (5.2.8.1) lib/action_view/template.rb:159:in `block in render'
activesupport (5.2.8.1) lib/active_support/notifications.rb:170:in `instrument'
actionview (5.2.8.1) lib/action_view/template.rb:354:in `instrument_render_template'
actionview (5.2.8.1) lib/action_view/template.rb:157:in `render'
actionview (5.2.8.1) lib/action_view/renderer/template_renderer.rb:54:in `block (2 levels) in render_template'
actionview (5.2.8.1) lib/action_view/renderer/abstract_renderer.rb:44:in `block in instrument'
activesupport (5.2.8.1) lib/active_support/notifications.rb:168:in `block in instrument'
activesupport (5.2.8.1) lib/active_support/notifications/instrumenter.rb:23:in `instrument'
activesupport (5.2.8.1) lib/active_support/notifications.rb:168:in `instrument'
actionview (5.2.8.1) lib/action_view/renderer/abstract_renderer.rb:43:in `instrument'
actionview (5.2.8.1) lib/action_view/renderer/template_renderer.rb:53:in `block in render_template'
actionview (5.2.8.1) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
actionview (5.2.8.1) lib/action_view/renderer/template_renderer.rb:52:in `render_template'
actionview (5.2.8.1) lib/action_view/renderer/template_renderer.rb:16:in `render'
actionview (5.2.8.1) lib/action_view/renderer/renderer.rb:44:in `render_template'
actionview (5.2.8.1) lib/action_view/renderer/renderer.rb:25:in `render'
actionview (5.2.8.1) lib/action_view/rendering.rb:103:in `_render_template'
actionview (5.2.8.1) lib/action_view/rendering.rb:84:in `render_to_body'
actionpack (5.2.8.1) lib/abstract_controller/rendering.rb:25:in `render'
actionpack (5.2.8.1) lib/action_controller/metal/rendering.rb:36:in `render'
actionpack (5.2.8.1) lib/action_controller/metal/instrumentation.rb:46:in `block (2 levels) in render'
activesupport (5.2.8.1) lib/active_support/core_ext/benchmark.rb:14:in `block in ms'
/usr/local/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
activesupport (5.2.8.1) lib/active_support/core_ext/benchmark.rb:14:in `ms'
actionpack (5.2.8.1) lib/action_controller/metal/instrumentation.rb:46:in `block in render'
actionpack (5.2.8.1) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
activerecord (5.2.8.1) lib/active_record/railties/controller_runtime.rb:31:in `cleanup_view_runtime'
actionpack (5.2.8.1) lib/action_controller/metal/instrumentation.rb:45:in `render'

```