### PR TITLE
Switched the ApplicationController base.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Switched from `ActionController::API` to `ActionController::Base` for the
+  engine's `ApplicationController` (#25)
 
 ### 1.4.1 (6 January 2025)
 
-* Reverted (#23) as it causes errors for unknown reasons
+* Reverted (#23) as it causes errors for unknown reasons (#24)
 
 ### 1.4.0 (6 January 2025)
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ application. The file
 this:
 
 ```ruby
-class Instrumentation::AuthenticationsController < ActionController::API
+class Instrumentation::AuthenticationsController \
+      < FactoryBot::Instrumentation::ApplicationController
   # Generate a new web app authentication URL for the given email address.
   # This endpoint creates new login URLs which are valid for 30 minutes.
   def create
@@ -271,8 +272,19 @@ routes like this:
 
 ```ruby
 Rails.application.routes.draw do
-  unless Rails.env.production?
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('INSTRUMENTATION_API',
+                                                   false))
     mount FactoryBot::Instrumentation::Engine => '/instrumentation'
+  end
+
+  # or with custom controllers in an namespace
+
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('INSTRUMENTATION_API',
+                                                   false))
+    namespace :instrumentation do
+      mount FactoryBot::Instrumentation::Engine => '/'
+      resource :authentication, only: :create
+    end
   end
 end
 ```

--- a/app/controllers/factory_bot/instrumentation/application_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/application_controller.rb
@@ -3,11 +3,17 @@
 module FactoryBot
   module Instrumentation
     # A base engine application controller.
-    class ApplicationController < ActionController::API
+    class ApplicationController < ActionController::Base
       # Extend our core functionality to support easy authentication logics
       include ActionController::HttpAuthentication::Basic::ControllerMethods
       include ActionController::HttpAuthentication::Digest::ControllerMethods
       include ActionController::HttpAuthentication::Token::ControllerMethods
+
+      # Rails 5.2 enabled CSRF protection by default, but this may be different
+      # on the host application. Therefore we cannot blindly disable it via
+      # +skip_forgery_protection+. We have to "enable" it for no routes, which
+      # eventually disables it entirely for this engine.
+      protect_from_forgery only: []
 
       # Allow the users to implement additional instrumentation-wide before
       # action logic, like authentication
@@ -18,8 +24,6 @@ module FactoryBot
           )
         end
       end
-
-      protected
 
       # A simple shortcut for Basic Auth on Rails 4.2+. Just configure the
       # username and password and you're ready to check the current request.
@@ -35,6 +39,53 @@ module FactoryBot
               given_password, password
             )
         end
+      end
+
+      # Unfortunately +Rails.configuration.instrumentation+ is only read once
+      # and do not hot-reload on changes. Thats why we read this file manually
+      # to get always a fresh state.
+      #
+      # @return [Hash{String => Mixed}] the instrumentation scenarios
+      def instrumentation
+        config_file = FactoryBot::Instrumentation.configuration.config_file.to_s
+        template = ERB.new(Pathname.new(config_file).read)
+        load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
+        YAML.send(load_method, template.result(binding))[Rails.env] || {}
+      end
+
+      # Map all the instrumentation scenarios into groups and pass them back.
+      #
+      # @return [Hash{String => Array}] the grouped scenarios
+      def scenarios
+        res = instrumentation['scenarios'] || []
+        res.each_with_object({}) do |scenario, memo|
+          group = scenario_group(scenario['name'])
+          scenario['group'] = group
+          memo[group] = [] unless memo.key? group
+          memo[group] << scenario
+        end
+      end
+
+      # Map all the configured scenario groups to a useable hash.
+      #
+      # @return [Hash{Regexp => String}] the group mapping
+      def groups
+        (instrumentation['groups'] || {}).transform_keys do |key|
+          Regexp.new(Regexp.quote(key))
+        end
+      end
+
+      # Fetch the group name for a given scenario name. This will utilize the
+      # +SCENARIO_GROUPS+ map.
+      #
+      # @param name [String] the scenario name
+      # @return [String] the group name
+      def scenario_group(name)
+        groups.map do |pattern, group_name|
+          next unless pattern.match? name
+
+          group_name
+        end.compact.first || 'Various'
       end
     end
   end

--- a/app/controllers/factory_bot/instrumentation/root_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/root_controller.rb
@@ -4,12 +4,6 @@ module FactoryBot
   module Instrumentation
     # The Instrumentation engine controller with frontend and API actions.
     class RootController < ApplicationController
-      # This is required to make API controllers template renderable
-      include ActionView::Layouts
-
-      # Configure the default application layout
-      layout 'factory_bot/instrumentation/application'
-
       # Show the instrumentation frontend which features the output of
       # configured dynamic seeds scenarios. The frontend allows humans to
       # generate new seed data on the fly.
@@ -53,8 +47,6 @@ module FactoryBot
         FactoryBot::Instrumentation.configuration.render_error.call(self, e)
       end
 
-      protected
-
       # Parse the given parameters from the request and build
       # a valid FactoryBot options set.
       #
@@ -79,53 +71,6 @@ module FactoryBot
         ]
       end
       # rubocop:enable Metrics/MethodLength
-
-      # Unfortunately +Rails.configuration.instrumentation+ is only read once
-      # and do not hot-reload on changes. Thats why we read this file manually
-      # to get always a fresh state.
-      #
-      # @return [Hash{String => Mixed}] the instrumentation scenarios
-      def instrumentation
-        config_file = FactoryBot::Instrumentation.configuration.config_file.to_s
-        template = ERB.new(Pathname.new(config_file).read)
-        load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
-        YAML.send(load_method, template.result(binding))[Rails.env] || {}
-      end
-
-      # Map all the instrumentation scenarios into groups and pass them back.
-      #
-      # @return [Hash{String => Array}] the grouped scenarios
-      def scenarios
-        res = instrumentation['scenarios'] || []
-        res.each_with_object({}) do |scenario, memo|
-          group = scenario_group(scenario['name'])
-          scenario['group'] = group
-          memo[group] = [] unless memo.key? group
-          memo[group] << scenario
-        end
-      end
-
-      # Map all the configured scenario groups to a useable hash.
-      #
-      # @return [Hash{Regexp => String}] the group mapping
-      def groups
-        (instrumentation['groups'] || {}).transform_keys do |key|
-          Regexp.new(Regexp.quote(key))
-        end
-      end
-
-      # Fetch the group name for a given scenario name. This will utilize the
-      # +SCENARIO_GROUPS+ map.
-      #
-      # @param name [String] the scenario name
-      # @return [String] the group name
-      def scenario_group(name)
-        groups.map do |pattern, group_name|
-          next unless pattern.match? name
-
-          group_name
-        end.compact.first || 'Various'
-      end
     end
   end
 end

--- a/lib/factory_bot/instrumentation/engine.rb
+++ b/lib/factory_bot/instrumentation/engine.rb
@@ -5,6 +5,7 @@ module FactoryBot
     # The Instrumentation engine which can be mounted.
     class Engine < ::Rails::Engine
       isolate_namespace FactoryBot::Instrumentation
+      engine_name 'factory_bot_instrumentation'
 
       # Fill in some dynamic settings (application related)
       initializer 'factory_bot_instrumentation.config' do |app|

--- a/spec/controllers/factory_bot/instrumentation/application_controller_spec.rb
+++ b/spec/controllers/factory_bot/instrumentation/application_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FactoryBot::Instrumentation::ApplicationController do
+  render_views
+  routes { FactoryBot::Instrumentation::Engine.routes }
+
+  describe '#groups' do
+    let(:action) { controller.send(:groups) }
+
+    it 'returns a hash with Regexp keys' do
+      expect(action.keys).to all(be_a(Regexp))
+    end
+
+    it 'returns a hash with string values' do
+      expect(action.values).to all(be_a(String))
+    end
+  end
+
+  describe '#scenario_group' do
+    let(:action) { controller.send(:scenario_group, name) }
+
+    context 'with a matching scenario name' do
+      let(:name) { 'UX Testcase #1' }
+
+      it 'returns the correct group name' do
+        expect(action).to eql('UX Scenarios')
+      end
+    end
+
+    context 'without a matching scenario name' do
+      let(:name) { 'Fancy Testcase #1' }
+
+      it 'returns the correct group name' do
+        expect(action).to eql('Various')
+      end
+    end
+  end
+end

--- a/spec/controllers/factory_bot/instrumentation/root_controller_spec.rb
+++ b/spec/controllers/factory_bot/instrumentation/root_controller_spec.rb
@@ -7,21 +7,6 @@ RSpec.describe FactoryBot::Instrumentation::RootController do
   render_views
   routes { FactoryBot::Instrumentation::Engine.routes }
 
-  before do
-    # Allow the spec to access the engines/main_app routes from its views
-    ActiveSupport.on_load(:action_view) do
-      include FactoryBot::Instrumentation::Engine.routes.url_helpers
-
-      def _routes
-        FactoryBot::Instrumentation::Engine.routes
-      end
-
-      def main_app
-        Rails.application.class.routes.url_helpers
-      end
-    end
-  end
-
   describe '#index' do
     before { get :index }
 
@@ -198,38 +183,6 @@ RSpec.describe FactoryBot::Instrumentation::RootController do
             expect(response).to have_http_status(:ok)
           end
         end
-      end
-    end
-  end
-
-  describe '#groups' do
-    let(:action) { controller.send(:groups) }
-
-    it 'returns a hash with Regexp keys' do
-      expect(action.keys).to all(be_a(Regexp))
-    end
-
-    it 'returns a hash with string values' do
-      expect(action.values).to all(be_a(String))
-    end
-  end
-
-  describe '#scenario_group' do
-    let(:action) { controller.send(:scenario_group, name) }
-
-    context 'with a matching scenario name' do
-      let(:name) { 'UX Testcase #1' }
-
-      it 'returns the correct group name' do
-        expect(action).to eql('UX Scenarios')
-      end
-    end
-
-    context 'without a matching scenario name' do
-      let(:name) { 'Fancy Testcase #1' }
-
-      it 'returns the correct group name' do
-        expect(action).to eql('Various')
       end
     end
   end


### PR DESCRIPTION
Follow up to: #23, #24

---

I think we finally figured out the root of all issues. By switching the inherited base class from `ActionController::API` to `ActionController::Base` at the engine's `ApplicationController` the routing/path helper issues disappeared. We no longer need to fiddle around with the routing on specs, and the layout/view messing at the controllers.

Now we *just* have to fiddle around with CSRF which is enabled by default with Rails 5.2 settings. But the `skip_forgery_protection` is not smart enough just to do nothing if not enabled. It will just raise an error if not enabled in the host application. We're working around it by "enabling" the CSRF protection for nothing at the `ApplicationController`.