### PR TITLE
Inherit explicit ApplicationController.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Sometimes the classic Rails autoloader is confused our engines
+  `RootController` does not inherit our engines `ApplicationController`, but
+  the one from host application, so we specify our dependency explicitly (#26)
 
 ### 1.5.0 (7 January 2025)
 

--- a/app/controllers/factory_bot/instrumentation/root_controller.rb
+++ b/app/controllers/factory_bot/instrumentation/root_controller.rb
@@ -3,7 +3,7 @@
 module FactoryBot
   module Instrumentation
     # The Instrumentation engine controller with frontend and API actions.
-    class RootController < ApplicationController
+    class RootController < FactoryBot::Instrumentation::ApplicationController
       # Show the instrumentation frontend which features the output of
       # configured dynamic seeds scenarios. The frontend allows humans to
       # generate new seed data on the fly.


### PR DESCRIPTION
```
NameError:
   undefined local variable or method `instrumentation' for #<FactoryBot::Instrumentation::RootController:0x000000000e0c40>
```

<details>
  <summary>Backtrace</summary>

```
 # ./vendor/bundle/ruby/2.7.0/gems/factory_bot_instrumentation-1.5.0/app/controllers/factory_bot/instrumentation/root_controller.rb:11:in `index'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/abstract_controller/base.rb:228:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/rendering.rb:30:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
 # ./vendor/bundle/ruby/2.7.0/gems/marginalia-1.11.1/lib/marginalia.rb:109:in `record_query_comment'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/callbacks.rb:126:in `block in run_callbacks'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/callbacks.rb:137:in `run_callbacks'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/abstract_controller/callbacks.rb:41:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/rescue.rb:22:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/notifications.rb:203:in `block in instrument'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/notifications.rb:203:in `instrument'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/instrumentation.rb:33:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.7.10/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/abstract_controller/base.rb:165:in `process'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal.rb:190:in `dispatch'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_controller/metal.rb:254:in `dispatch'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/route_set.rb:33:in `serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:50:in `block in serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:32:in `each'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:32:in `serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/route_set.rb:842:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/engine.rb:539:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/railtie.rb:207:in `public_send'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/railtie.rb:207:in `method_missing'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/mapper.rb:20:in `block in <class:Constraints>'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/mapper.rb:49:in `serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:50:in `block in serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:32:in `each'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/journey/router.rb:32:in `serve'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/routing/route_set.rb:842:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/tempfile_reaper.rb:15:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/etag.rb:27:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/conditional_get.rb:27:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/head.rb:12:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/http/permissions_policy.rb:22:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/http/content_security_policy.rb:19:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/session/abstract/id.rb:266:in `context'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/session/abstract/id.rb:260:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/cookies.rb:697:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/callbacks.rb:98:in `run_callbacks'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/appsignal-3.13.1/lib/appsignal/rack/abstract_middleware.rb:67:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/debug_exceptions.rb:29:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/rack/logger.rb:37:in `call_app'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/rack/logger.rb:28:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/request_id.rb:26:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/method_override.rb:24:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/runtime.rb:22:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.7.10/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/executor.rb:14:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/static.rb:24:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/sendfile.rb:110:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/middleware/host_authorization.rb:142:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-2.2.10/lib/rack/events.rb:112:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/grape-1.8.0/lib/grape/middleware/base.rb:36:in `call!'
 # ./vendor/bundle/ruby/2.7.0/gems/grape-1.8.0/lib/grape/middleware/base.rb:29:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/railties-6.1.7.10/lib/rails/engine.rb:539:in `call'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-test-2.2.0/lib/rack/test.rb:360:in `process_request'
 # ./vendor/bundle/ruby/2.7.0/gems/rack-test-2.2.0/lib/rack/test.rb:153:in `request'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/testing/integration.rb:279:in `process'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/testing/integration.rb:16:in `get'
 # ./vendor/bundle/ruby/2.7.0/gems/actionpack-6.1.7.10/lib/action_dispatch/testing/integration.rb:372:in `get'
```
  
</details>
