### PR TITLE
Added all versions up to Ruby 3.4 to the CI matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         rails: ['6.1', '7.1']
     env:
       BUNDLE_GEMFILE: 'gemfiles/rails_${{ matrix.rails }}.gemfile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Added all versions up to Ruby 3.4 to the CI matrix (#29)
 
 ### 1.6.1 (17 January 2025)
 

--- a/factory_bot_instrumentation.gemspec
+++ b/factory_bot_instrumentation.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bigdecimal', '~> 3.1'
   spec.add_dependency 'factory_bot', '~> 6.2'
+  spec.add_dependency 'mutex_m', '~> 0.3.0'
   spec.add_dependency 'rails', '>= 6.1'
   spec.add_dependency 'retries', '>= 0.0.5'
   spec.add_dependency 'zeitwerk', '~> 2.6'

--- a/factory_bot_instrumentation.gemspec
+++ b/factory_bot_instrumentation.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
+  spec.add_dependency 'bigdecimal', '~> 3.1'
   spec.add_dependency 'factory_bot', '~> 6.2'
   spec.add_dependency 'rails', '>= 6.1'
   spec.add_dependency 'retries', '>= 0.0.5'

--- a/factory_bot_instrumentation.gemspec
+++ b/factory_bot_instrumentation.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'bigdecimal', '~> 3.1'
+  spec.add_dependency 'drb', '~> 2.2'
   spec.add_dependency 'factory_bot', '~> 6.2'
   spec.add_dependency 'mutex_m', '~> 0.3.0'
   spec.add_dependency 'rails', '>= 6.1'


### PR DESCRIPTION
See: https://github.com/hausgold/env/issues/308